### PR TITLE
fix(bulk entry): change last date calculation and remove blank lines

### DIFF
--- a/src/components/bulk-entry.vue
+++ b/src/components/bulk-entry.vue
@@ -169,7 +169,7 @@ export default Vue.extend({
 
       reader.onload = () => {
         if (reader.result) {
-          let strs = (reader.result as string).split('\n');
+          let strs = (reader.result as string).split('\n').filter(str => str !== '');
 
           // Map of property key to possible columns
           const columnDict: KeyAccessor = {
@@ -224,12 +224,10 @@ export default Vue.extend({
           });
 
           // if date picker is filled use it, otherwise most recent time
-          const lastTime = Math.max.apply(
-            Math,
-            parsedReadings.map((o: any) => {
-              return o.time;
-            })
-          );
+          const lastTime = parsedReadings.reduce((dateA: IDataEntryState, dateB: IDataEntryState) =>
+            moment(dateA.time).unix() > moment(dateB.time).unix() ? dateA : dateB
+          ).time;
+          console.log(lastTime);
           this.goal_time = this.goal_time ? moment(this.goal_time).format('MM/DD/YYYY') : lastTime;
 
           // Set the readings


### PR DESCRIPTION
This is a quick fix for the issue Joe ran into where the data wasn't uploading when the date wasn't specified. I _think_ that was the issue, but joe's answers were slightly unclear. 

Times were previously being compared as strings and now they are compared by there unix timestamp values. Blank times are filtered out now so that they don't interfere with the time stamp comparison.